### PR TITLE
create logs in temp directory

### DIFF
--- a/docs/notebooks/cenove_udaje_dle_ku_json_zip.ipynb
+++ b/docs/notebooks/cenove_udaje_dle_ku_json_zip.ipynb
@@ -44,7 +44,15 @@
    "execution_count": 2,
    "id": "b71f2fbd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "generujCenoveUdajeDleKu - INFO     - Logovaci zpravy ulozeny v adresari: /tmp/generujCenoveUdajeDleKu\n"
+     ]
+    }
+   ],
    "source": [
     "creds_test = [\"WSTEST\", \"WSHESLO\"]\n",
     "cen_udaje = GenerujCenoveUdajeDleKu(creds_test, trial=True)"
@@ -247,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/ctios_db.ipynb
+++ b/docs/notebooks/ctios_db.ipynb
@@ -45,7 +45,15 @@
    "execution_count": 2,
    "id": "6a289697",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ctiOS        - INFO     - Logovaci zpravy ulozeny v adresari: /tmp/tmpnkbc9w5u\n"
+     ]
+    }
+   ],
    "source": [
     "creds_test = [\"WSTEST\", \"WSHESLO\"]\n",
     "ctios = CtiOS(creds_test, trial=True)"
@@ -61,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "d330f440",
    "metadata": {},
    "outputs": [],
@@ -73,6 +81,32 @@
     "vystupni_adresar = os.path.abspath(\n",
     "    os.path.join(library_path, \"tests\", \"data\", \"output\")\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cf876bf",
+   "metadata": {},
+   "source": [
+    "Pokud chceme změnit cestu k logovacímu adresáři, uděláme to následovně:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b1f71745",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ctiOS        - INFO     - Logovaci adresar nastaven na cestu: /home/linduska/pywsdp/logs\n"
+     ]
+    }
+   ],
+   "source": [
+    "ctios.log_adresar = \"/home/linduska/pywsdp/logs\""
    ]
   },
   {

--- a/docs/notebooks/ctios_db.ipynb
+++ b/docs/notebooks/ctios_db.ipynb
@@ -50,7 +50,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ctiOS        - INFO     - Logovaci zpravy ulozeny v adresari: /tmp/tmpnkbc9w5u\n"
+      "ctiOS        - INFO     - Logovaci zpravy ulozeny v adresari: /tmp/ctiOS\n"
      ]
     }
    ],
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "d330f440",
    "metadata": {},
    "outputs": [],
@@ -254,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/ctios_json_csv.ipynb
+++ b/docs/notebooks/ctios_json_csv.ipynb
@@ -45,7 +45,15 @@
    "execution_count": 2,
    "id": "b71f2fbd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ctiOS        - INFO     - Logovaci zpravy ulozeny v adresari: /tmp/ctiOS\n"
+     ]
+    }
+   ],
    "source": [
     "creds_test = [\"WSTEST\", \"WSHESLO\"]\n",
     "ctios = CtiOS(creds_test, trial=True)"
@@ -61,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "654c8be8",
    "metadata": {},
    "outputs": [],
@@ -255,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/spravuj_sestavy.ipynb
+++ b/docs/notebooks/spravuj_sestavy.ipynb
@@ -45,7 +45,15 @@
    "execution_count": 2,
    "id": "b71f2fbd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "generujCenoveUdajeDleKu - INFO     - Logovaci zpravy ulozeny v adresari: /tmp/generujCenoveUdajeDleKu\n"
+     ]
+    }
+   ],
    "source": [
     "creds_test = [\"WSTEST\", \"WSHESLO\"]\n",
     "cen_udaje = GenerujCenoveUdajeDleKu(creds_test, trial=True)"
@@ -189,7 +197,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/pywsdp/base/__init__.py
+++ b/pywsdp/base/__init__.py
@@ -102,7 +102,7 @@ class WSDPBase:
     def _set_default_log_dir(self) -> str:
         """Privatni metoda pro nasteveni logovaciho adresare."""
 
-        log_dir = os.path.join(tempfile.gettempdir(), self.nazev_sluzby)        
+        log_dir = os.path.join(tempfile.gettempdir(), self.nazev_sluzby)
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
         self.logger.set_directory(log_dir)

--- a/pywsdp/base/__init__.py
+++ b/pywsdp/base/__init__.py
@@ -64,7 +64,8 @@ class WSDPBase:
 
     @property
     def log_adresar(self) -> str:
-        """Vypise cestu k adresari, ve kterem se budou vytvaret log soubory."""
+        """Vypise cestu k adresari, ve kterem se budou vytvaret log soubory.
+        Zaroven funguje i jako setter pro nastaveni vlastniho logovaciho adresare."""
         return self._log_adresar
 
     @log_adresar.setter
@@ -78,6 +79,7 @@ class WSDPBase:
             os.makedirs(log_adresar)
         self.logger.set_directory(log_adresar)
         self._log_adresar = log_adresar
+        self.logger.info("Logovaci adresar nastaven na cestu: {}".format(log_adresar))
 
     @property
     def testovaci_mod(self) -> bool:

--- a/pywsdp/base/__init__.py
+++ b/pywsdp/base/__init__.py
@@ -102,7 +102,7 @@ class WSDPBase:
     def _set_default_log_dir(self) -> str:
         """Privatni metoda pro nasteveni logovaciho adresare."""
 
-        log_dir = tempfile.TemporaryDirectory().name
+        log_dir = os.path.join(tempfile.gettempdir(), self.nazev_sluzby)        
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
         self.logger.set_directory(log_dir)

--- a/pywsdp/base/__init__.py
+++ b/pywsdp/base/__init__.py
@@ -13,6 +13,7 @@ This library is free under the MIT License.
 
 import os
 import json
+import tempfile
 from pathlib import Path
 
 from pywsdp.clients.factory import pywsdp
@@ -99,21 +100,11 @@ class WSDPBase:
     def _set_default_log_dir(self) -> str:
         """Privatni metoda pro nasteveni logovaciho adresare."""
 
-        def is_run_by_jupyter():
-            import __main__ as main
-
-            return not hasattr(main, "__file__")
-
-        if is_run_by_jupyter():
-            module_dir = os.path.abspath(os.path.join("../../"))
-        else:
-            module_dir = os.path.abspath(
-                os.path.join(os.path.dirname(__file__), "..", "..")
-            )
-        log_dir = os.path.join(module_dir, "logs")
+        log_dir = tempfile.TemporaryDirectory().name
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
         self.logger.set_directory(log_dir)
+        self.logger.info("Logovaci zpravy ulozeny v adresari: {}".format(log_dir))
         return log_dir
 
 

--- a/pywsdp/base/__init__.py
+++ b/pywsdp/base/__init__.py
@@ -20,7 +20,7 @@ from pywsdp.clients.factory import pywsdp
 from pywsdp.base.logger import WSDPLogger
 from pywsdp.base.exceptions import WSDPError
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 
 class WSDPBase:


### PR DESCRIPTION
Creating logs in installation dependent directory `__file__/../..` may cause problems due to missing write permissions. Using pywsdp library in QGIS plugin on Windows leads to error message below: 

```
Unable to create C:\Users\logs
```

This draft PR creates logs in temporary directory instead of installation dependent path.

Tasks before merging:

- [x] user should have possibility to defined own log directory (as constructor's argument / method / or env variable)